### PR TITLE
Instala net telnet gem

### DIFF
--- a/lib/mail_box_validator/mail_box.rb
+++ b/lib/mail_box_validator/mail_box.rb
@@ -1,4 +1,5 @@
 require 'net/telnet'
+require 'singleton'
 
 module MailBoxValidator
   class MailBox

--- a/mail_box_validator.gemspec
+++ b/mail_box_validator.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
+
+  spec.add_dependency 'net-telnet'
 end


### PR DESCRIPTION
PR criado para instalar a gem [net-telnet](https://github.com/ruby/net-telnet) que não faz parte mais do pacote ruby na versão 2.3 e adiciono a classe Singleton.
